### PR TITLE
Update adafruit_max1704x.py for board ESP323-S3 (no psram)

### DIFF
--- a/adafruit_max1704x.py
+++ b/adafruit_max1704x.py
@@ -124,7 +124,7 @@ class MAX17048:
             pass
         else:
             raise RuntimeError("Reset did not succeed")
-        for _ in range(2):
+        for _ in range(3):
             try:
                 self.reset_alert = False  # clean up RI alert
                 return


### PR DESCRIPTION
I was getting the exception "Clearing reset alert did not succeed" when trying to initialize the MAX17048 battery monitor on the ESP32-S3 (no psram) board.

I'm running with CircuitPython 8.0.4 and the 8.x Library Bundles built on 3/27/2023.

The line of code giving the error was `monitor = adafruit_max1704x.MAX17048(board.I2C())` By changing the loop to run 3 times fixed the issue for me, and I see the comment saying on this board it fails to reset the first time. Like my old mentor used to say, if twice is good three times is better :)