### PR TITLE
Fix Issue 16, +1 from Issue #6 and use round vs int for setters

### DIFF
--- a/adafruit_max1704x.py
+++ b/adafruit_max1704x.py
@@ -58,9 +58,7 @@ _MAX1704X_CHIPID_REG = const(0x19)
 _MAX1704X_STATUS_REG = const(0x1A)
 _MAX1704X_CMD_REG = const(0xFE)
 
-# Issue #16 fix
-# Datasheet 19-6171 Rev 7, timings: after a full POR-equivalent reset (CMD=0x5400),
-# the IC needs up to 17ms (OCV ready) + 175ms (SOC ready) = 192ms worst-case before
+# IC needs up to 17ms (OCV ready) + 175ms (SOC ready) = 192ms worst-case before
 # VCELL/SOC reflect a real measurement rather than the power-on sentinel. See reset().
 _MAX1704X_TPOR_MAX = 0.192
 
@@ -134,10 +132,8 @@ class MAX17048:
             pass
         else:
             raise RuntimeError("Reset did not succeed")
-        # A full POR-equivalent reset needs its own settle wait, without this a caller
-        # reading cell_voltage immediately after construction silently gets the
-        # uninitialized-register sentinel (0V) instead of a real reading, because
-        # VCELL/SOC aren't valid until tPOR_MAX has elapsed. Fixes Issue #16.
+        # A full POR-equivalent reset needs its own settle wait of tPOR-MAX or
+        # incorrect 0V sentinel returned on immediate read after reset
         time.sleep(_MAX1704X_TPOR_MAX)
         for _ in range(3):
             try:
@@ -169,8 +165,7 @@ class MAX17048:
         """The voltage that will determine whether the chip will consider it a reset/swap"""
         return self._reset_voltage * 0.04  # 40mV / LSB
 
-    # int() truncates toward zero (asymmetric, up to 1 LSB low); round() matches the intended
-    # nearest-code encoding. All following setters now use round vs int
+    # All following setters use round for nearest-value encoding.
 
     @reset_voltage.setter
     def reset_voltage(self, reset_v: float) -> None:

--- a/adafruit_max1704x.py
+++ b/adafruit_max1704x.py
@@ -88,9 +88,6 @@ class MAX17048:
 
     _config = ROUnaryStruct(_MAX1704X_CONFIG_REG, ">H")
     # expose the config bits
-    # The datasheet requires all registers be written as full 16-bit words --
-    # "8-bit writes cause no effect". The original code anchored at CONFIG_REG + 1
-    # instead of CONFIG_REG, landing one byte past the real register (0x0E).
     sleep = RWBit(_MAX1704X_CONFIG_REG, 7, register_width=2, lsb_first=False)
     _alert_status = RWBit(_MAX1704X_CONFIG_REG, 5, register_width=2, lsb_first=False)
     enable_sleep = RWBit(_MAX1704X_MODE_REG, 5)

--- a/adafruit_max1704x.py
+++ b/adafruit_max1704x.py
@@ -27,6 +27,8 @@ Implementation Notes
 * Adafruit's Register library: https://github.com/adafruit/Adafruit_CircuitPython_Register
 """
 
+import time
+
 from adafruit_bus_device import i2c_device
 from adafruit_register.i2c_bit import ROBit, RWBit
 from adafruit_register.i2c_bits import RWBits
@@ -56,6 +58,12 @@ _MAX1704X_CHIPID_REG = const(0x19)
 _MAX1704X_STATUS_REG = const(0x1A)
 _MAX1704X_CMD_REG = const(0xFE)
 
+# Issue #16 fix
+# Datasheet 19-6171 Rev 7, timings: after a full POR-equivalent reset (CMD=0x5400),
+# the IC needs up to 17ms (OCV ready) + 175ms (SOC ready) = 192ms worst-case before
+# VCELL/SOC reflect a real measurement rather than the power-on sentinel. See reset().
+_MAX1704X_TPOR_MAX = 0.192
+
 ALERTFLAG_SOC_CHANGE = 0x20
 ALERTFLAG_SOC_LOW = 0x10
 ALERTFLAG_VOLTAGE_RESET = 0x08
@@ -71,12 +79,20 @@ class MAX17048:
     """
 
     chip_version = ROUnaryStruct(_MAX1704X_VERSION_REG, ">H")
+    # This is the factory-programmed, one-time-provisioned lot/production ID (datasheet
+    # ID field, low byte of the VRESET/ID register at 0x19) -- NOT a chip/part-number
+    # identifier. It does not distinguish MAX17048 from MAX17049 and should not be used
+    # as a "device present and correct" check; chip_version's masked comparison in
+    # __init__ already serves that purpose.
     chip_id = ROUnaryStruct(_MAX1704X_CHIPID_REG, ">B")
 
     _config = ROUnaryStruct(_MAX1704X_CONFIG_REG, ">H")
     # expose the config bits
-    sleep = RWBit(_MAX1704X_CONFIG_REG + 1, 7, register_width=2, lsb_first=False)
-    _alert_status = RWBit(_MAX1704X_CONFIG_REG + 1, 5, register_width=2, lsb_first=False)
+    # The datasheet requires all registers be written as full 16-bit words --
+    # "8-bit writes cause no effect". The original code anchored at CONFIG_REG + 1
+    # instead of CONFIG_REG, landing one byte past the real register (0x0E).
+    sleep = RWBit(_MAX1704X_CONFIG_REG, 7, register_width=2, lsb_first=False)
+    _alert_status = RWBit(_MAX1704X_CONFIG_REG, 5, register_width=2, lsb_first=False)
     enable_sleep = RWBit(_MAX1704X_MODE_REG, 5)
     hibernating = ROBit(_MAX1704X_MODE_REG, 4)
     quick_start = RWBit(_MAX1704X_MODE_REG, 6)
@@ -121,6 +137,11 @@ class MAX17048:
             pass
         else:
             raise RuntimeError("Reset did not succeed")
+        # A full POR-equivalent reset needs its own settle wait, without this a caller
+        # reading cell_voltage immediately after construction silently gets the
+        # uninitialized-register sentinel (0V) instead of a real reading, because
+        # VCELL/SOC aren't valid until tPOR_MAX has elapsed. Fixes Issue #16.
+        time.sleep(_MAX1704X_TPOR_MAX)
         for _ in range(3):
             try:
                 self.reset_alert = False  # clean up RI alert
@@ -151,11 +172,14 @@ class MAX17048:
         """The voltage that will determine whether the chip will consider it a reset/swap"""
         return self._reset_voltage * 0.04  # 40mV / LSB
 
+    # int() truncates toward zero (asymmetric, up to 1 LSB low); round() matches the intended
+    # nearest-code encoding. All following setters now use round vs int
+
     @reset_voltage.setter
     def reset_voltage(self, reset_v: float) -> None:
         if not 0 <= reset_v <= (127 * 0.04):
             raise ValueError("Reset voltage must be between 0 and 5.1 Volts")
-        self._reset_voltage = int(reset_v / 0.04)  # 40mV / LSB
+        self._reset_voltage = round(reset_v / 0.04)  # 40mV / LSB
 
     @property
     def voltage_alert_min(self) -> float:
@@ -166,7 +190,7 @@ class MAX17048:
     def voltage_alert_min(self, minvoltage: float) -> None:
         if not 0 <= minvoltage <= (255 * 0.02):
             raise ValueError("Alert voltage must be between 0 and 5.1 Volts")
-        self._valrt_min = int(minvoltage / 0.02)  # 20mV / LSB
+        self._valrt_min = round(minvoltage / 0.02)  # 20mV / LSB
 
     @property
     def voltage_alert_max(self) -> float:
@@ -177,7 +201,7 @@ class MAX17048:
     def voltage_alert_max(self, maxvoltage: float) -> None:
         if not 0 <= maxvoltage <= (255 * 0.02):
             raise ValueError("Alert voltage must be between 0 and 5.1 Volts")
-        self._valrt_max = int(maxvoltage / 0.02)  # 20mV / LSB
+        self._valrt_max = round(maxvoltage / 0.02)  # 20mV / LSB
 
     @property
     def active_alert(self) -> bool:
@@ -198,7 +222,7 @@ class MAX17048:
     def activity_threshold(self, threshold_voltage: float) -> None:
         if not 0 <= threshold_voltage <= (255 * 0.00125):
             raise ValueError("Activity voltage change must be between 0 and 0.31875 Volts")
-        self._hibrt_actthr = int(threshold_voltage / 0.00125)  # 1.25mV per LSB
+        self._hibrt_actthr = round(threshold_voltage / 0.00125)  # 1.25mV per LSB
 
     @property
     def hibernation_threshold(self) -> float:
@@ -210,7 +234,7 @@ class MAX17048:
     def hibernation_threshold(self, threshold_percent: float) -> None:
         if not 0 <= threshold_percent <= (255 * 0.208):
             raise ValueError("Activity percentage/hour change must be between 0 and 53%")
-        self._hibrt_hibthr = int(threshold_percent / 0.208)  # 0.208% per hour
+        self._hibrt_hibthr = round(threshold_percent / 0.208)  # 0.208% per hour
 
     def hibernate(self) -> None:
         """Setup thresholds for hibernation to go into hibernation mode immediately.

--- a/hw_tests/00_max17048.py
+++ b/hw_tests/00_max17048.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2026 for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+hw_tests/00_max17048.py
+
+Hardware-validated on: Unexpected Maker S3 (S3[D]) and Adafruit Feather ESP32-S3
+N4R2, both with the MAX17048 fuel gauge.
+
+On-hardware regression tests for the PR1 fixes to adafruit_max1704x.py:
+  - Issue #16: reset()/__init__ must block ~192ms before returning, so an
+    immediate read doesn't hit the uninitialized VCELL sentinel (0V).
+  - sleep / active_alert must address the real CONFIG LSB byte (0x0D), not
+    the undocumented byte one past it (0x0E).
+  - Threshold setters must round() to the nearest code, not truncate.
+"""
+
+import time
+
+import board
+import busio
+
+import adafruit_max1704x
+
+passed = 0
+failed = 0
+
+
+def test(name, condition):
+    global passed, failed
+    if condition:
+        print(f"PASS: {name}")
+        passed += 1
+    else:
+        print(f"FAIL: {name}")
+        failed += 1
+
+
+try:
+    i2c = board.STEMMA_I2C()
+except Exception:
+    i2c = None
+
+try:
+    if i2c is None:
+        i2c = busio.I2C(board.SCL, board.SDA)
+
+    # --- Issue #16: reset() must block for the datasheet's OCV+SOC-ready window ---
+    t0 = time.monotonic()
+    sensor = adafruit_max1704x.MAX17048(i2c)
+    elapsed = time.monotonic() - t0
+    test("Sensor found", True)
+    test(f"__init__ blocked for tPOR_MAX, elapsed={elapsed:.3f}s [Issue #16]", elapsed >= 0.19)
+
+    voltage = sensor.cell_voltage
+    print(f"  cell_voltage immediately after construction: {voltage:.4f}V")
+    test("cell_voltage nonzero immediately after construction [Issue #16]", voltage > 0.5)
+
+    # --- BugFix #2: sleep / active_alert must hit the real CONFIG byte (0x0D) ---
+    # _config is a raw ground-truth read of the whole 16-bit CONFIG register,
+    # independent of the (formerly incorrect) sleep/active_alert descriptors.
+    #
+    # Datasheet: "SLEEP forces the IC in or out of sleep mode if MODE.EnSleep is
+    # set." __init__ leaves EnSleep disarmed, so CONFIG.SLEEP must be armed here
+    # first -- this is a real chip gate, not a workaround for the address fix.
+    sensor.enable_sleep = True
+    sensor.sleep = True
+    raw_after_set = sensor._config
+    test(
+        "CONFIG.SLEEP bit (0x0D bit7) set via `.sleep = True` w/ EnSleep armed [BugFix #2]",
+        bool(raw_after_set & 0x0080),
+    )
+
+    sensor.sleep = False
+    raw_after_clear = sensor._config
+    test(
+        "CONFIG.SLEEP bit clears via `.sleep = False` [BugFix #2]",
+        not bool(raw_after_clear & 0x0080),
+    )
+    sensor.enable_sleep = False  # restore __init__'s disarmed default
+
+    raw_alrt = bool(sensor._config & 0x0020)
+    test(
+        "active_alert agrees with raw CONFIG.ALRT bit (0x0D bit5) [BugFix #2]",
+        sensor.active_alert == raw_alrt,
+    )
+
+    # --- BugFix #3: threshold setters must round(), not truncate ---
+    # 0.002 / 0.00125 = 1.6 -> round()=2 (readback 0.0025V); the old int()
+    # behavior would truncate to 1 (readback 0.00125V). Only readback can
+    # distinguish the two, so this is a genuine regression guard.
+    sensor.activity_threshold = 0.002
+    readback = sensor.activity_threshold
+    test(
+        f"activity_threshold rounds 0.002V to nearest code, readback={readback:.5f}V, "
+        + "expect ~0.0025V [BugFix #3]",
+        abs(readback - 0.0025) < 1e-9,
+    )
+
+except Exception as e:
+    print(f"FAIL: Unhandled exception: {e}")
+    failed += 1
+
+print(f"=== Summary: {passed} passed, {failed} failed ===")
+print("ALL TESTS PASSED" if passed > 0 and failed == 0 else "SOME TESTS FAILED")
+print("~~END~~")

--- a/ruff.toml
+++ b/ruff.toml
@@ -100,5 +100,9 @@ ignore = [
     "PLR0916", # too-many-boolean-expressions
 ]
 
+exclude = [
+  "hw_tests/*.py"
+]
+
 [format]
 line-ending = "lf"


### PR DESCRIPTION
# Bug fixes: reset timing, wrong register byte, and rounding in threshold setters

(I might have been too verbose in the datasheet description in the actual library include file -- getting used to the right mix).  I do have to say this one PR is special as I'm fixing Issue #16 that I raised back in February.

Fixes Issue #16 (first item below) also fixes previous stale pull request #6 mentioning register +1 error from 2022.

- **`reset()` didn't wait for the IC to finish its POR-equivalent reset before
  returning.** Per datasheet, VCELL/SOC aren't valid until ~192ms (17ms OCV-ready +
  175ms SOC-ready) after the full-reset command (`CMD=0x5400`). A caller reading
  `cell_voltage` immediately after construction got the uninitialized-register sentinel
  (0V) instead of a real reading. `reset()` now sleeps the datasheet's documented max
  before returning.
- **`sleep` and `active_alert` addressed the wrong I²C byte. Fixed by anchoring at the 
  register's true base address (`0x0C`, not `0x0C + 1`)
- **Threshold/limit setters truncated instead of rounding.** `reset_voltage`,
  `voltage_alert_min`, `voltage_alert_max`, `activity_threshold`, and
  `hibernation_threshold` all used `int(value / lsb)`, which truncates toward zero and
  lands on the wrong code for roughly half of realistic inputs. Switched to `round()`.
- **`chip_id` docstring clarified** (no behavior change) — it's the factory-programmed
  lot ID, not a device/variant identifier.

No API removals, no new exception types. The only externally-visible behavior changes:
`reset()`/`__init__` now takes ~192ms longer (necessary, see above), and the five
threshold setters may write a code up to 1 LSB different than before for the same input
(more accurate, not less).

**Testing:** `hw_tests/00_max17048.py` (added) — timing check on `__init__`, raw-register
ground truth for the sleep/alert bit fix, and a round-trip that distinguishes the new
`round()` behavior from the old `int()` behavior. Hardware-validated on: Unexpected Maker
S3 (S3[D]) and Adafruit Feather Rev TFT ESP32-S3 and Feather TFT ESP32-S2, with the MAX17048 
fuel gauge.


_Note: I use Claude Code to aid in library and datasheet analysis and coding of fixes.  
I personally double check all diffs and new functions against the datasheet._